### PR TITLE
fix: resolve possible unhandled promise rejection, move verify code a…

### DIFF
--- a/app/(auth)/_layout.tsx
+++ b/app/(auth)/_layout.tsx
@@ -35,7 +35,7 @@ export default function AuthLayout() {
                 name="verify-code"
                 options={{
                     headerShown: true,
-                    headerTitle: (props) => <Header />,
+                    headerTitle: "Nhập mã xác thực",
                     headerStyle: {
                         backgroundColor: '#c21c1c',
                     },

--- a/app/(auth)/sign-in.tsx
+++ b/app/(auth)/sign-in.tsx
@@ -19,10 +19,10 @@ import { useErrorContext } from '@/utils/ctx';
 import { ForbiddenException } from '@/utils/exception';
 
 const SignInScreen: React.FC = () => {
-    const { email: passedEmail } = useLocalSearchParams<{ email?: string }>();
+    const { email: passedEmail, password: passedPassword } = useLocalSearchParams<{ email?: string; password?: string }>();
 
     const [email, setEmail] = useState<string>(passedEmail || '');
-    const [password, setPassword] = useState<string>('');
+    const [password, setPassword] = useState<string>(passedPassword || '');
     const [isPasswordVisible, setPasswordVisible] = useState<boolean>(false);
     const [emailError, setEmailError] = useState<string>('');
     const [passwordError, setPasswordError] = useState<string>('');
@@ -33,12 +33,6 @@ const SignInScreen: React.FC = () => {
     const [forgotEmailError, setForgotEmailError] = useState<string>('');
     const { setUnhandledError } = useErrorContext(); // Dialog báo lỗi
     const passwordInputRef = useRef<TextInput>(null); // Tạo ref cho ô nhập mật khẩu
-    // Nếu có email từ tham số, focus vào ô mật khẩu
-    useEffect(() => {
-        if (passedEmail) {
-            passwordInputRef.current?.focus();
-        }
-    }, [passedEmail]);
 
     //Kiểm tra định dạng Email
     const isValidEmail = (email: string): boolean => {

--- a/app/(auth)/sign-up.tsx
+++ b/app/(auth)/sign-up.tsx
@@ -150,8 +150,9 @@ const SignUpScreen: React.FC = () => {
       };
 
       const response = await signUp(requestBody);
-      console.log("Mã xác minh:", response.verify_code);
-      router.push({ pathname: "/(auth)/verify-code", params: { email, password } });
+      const verify_code = response.verify_code;
+      console.log("Mã xác minh:", verify_code);
+      router.push({ pathname: "/(auth)/verify-code", params: { email, password, verify_code } });
 
     } catch (error: any) {
       setUnhandledError(error);

--- a/app/(auth)/verify-code.tsx
+++ b/app/(auth)/verify-code.tsx
@@ -8,10 +8,15 @@ import { useErrorContext } from "@/utils/ctx";
 import { GeneralErrorDialog } from "@/components/GeneralErrorDialog";
 
 const VerifyCodeScreen: React.FC = () => {
-  const [code, setCode] = useState<string>("");
+  const { email, password, verify_code, fromSignIn } = useLocalSearchParams() as {
+    email: string;
+    password: string;
+    verify_code: string;
+    fromSignIn: string;
+  };
+  const [code, setCode] = useState<string>(verify_code || "");
   const [codeError, setCodeError] = useState<String>("");
 
-  const { email, password, fromSignIn } = useLocalSearchParams();
   const isFromSignIn = fromSignIn === "true";
 
   const navigation = useNavigation();
@@ -61,11 +66,10 @@ const VerifyCodeScreen: React.FC = () => {
 
     //Nếu đúng định dạng
     return true;
-  }
+  };
 
   const [isChecking, setIsChecking] = useState(false);
   const [isSuccess, setIsSuccess] = useState(false); //Dùng để bật/tắt animation bàn tay
-
 
   const handleCheckVerifyCode = async () => {
     if (isChecking) return;
@@ -99,10 +103,9 @@ const VerifyCodeScreen: React.FC = () => {
 
         router.replace({
           pathname: "/(auth)/sign-in",
-          params: { email: Array.isArray(email) ? email[0] : email },
+          params: { email, password },
         });
       }, 3000);
-
     } catch (error: any) {
       setUnhandledError(error);
     } finally {
@@ -159,13 +162,13 @@ const VerifyCodeScreen: React.FC = () => {
 
       // Nếu thành công, bắt đầu đếm ngược
       setResendTimer(120);
+      setCode(response.verify_code);
       setErrorDialog({
         isVisible: true,
         title: "Thành công",
         content: "Mã xác thực đã được gửi lại. Vui lòng kiểm tra email của bạn!",
         onClickPositiveBtn: () => setErrorDialog({ ...errorDialog, isVisible: false }),
       });
-
     } catch (error: any) {
       setUnhandledError(error);
     } finally {


### PR DESCRIPTION
…bove input in verify-code screen, and pass password back to sign-in on success:
- Updated header logic to suppress "possible unhandled promise rejection" warnings.
- Moved verification code display above the input field for better UX.
- Passed password from verify-code screen to sign-in screen after successful registration.